### PR TITLE
Update permit method to return wait when CPU usage exceeds 50%

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -62,6 +62,10 @@ func (pl *CustomSchedulerPlugin) Permit(ctx context.Context, state *framework.Cy
 
 	fmt.Printf("CPU usage of node %s: %d%%\n", nodeName, int(cpuUsagePercentage))
 
+	if cpuUsagePercentage > 50 {
+		return framework.NewStatus(framework.Wait, "", time.Duration(10)*time.Second)
+	}
+
 	return framework.NewStatus(framework.Success, "")
 }
 


### PR DESCRIPTION
Modify the `permit` method in `plugin/plugin.go` to return `framework.Wait` when CPU usage exceeds 50%.

* Add a condition to check if CPU usage percentage is greater than 50.
* Return `framework.NewStatus(framework.Wait, "", time.Duration(10)*time.Second)` if CPU usage exceeds 50%.
* Return `framework.Success` if CPU usage is 50% or below.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogakzbj9/customScheduler?shareId=a669085a-75b9-47cc-b2d2-a222d239c40a).