### PR TITLE
Add custom scheduler deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To deploy the custom scheduler plugin to your Kubernetes cluster, follow these s
    - `waitTime`: 10
 2. Deploy the custom scheduler plugin as a Kubernetes Deployment:
    ```sh
-   kubectl apply -f deployment.yaml
+   kubectl apply -f custom-scheduler-deployment.yaml
    ```
 3. Verify that the custom scheduler plugin is running:
    ```sh

--- a/custom-scheduler-deployment.yaml
+++ b/custom-scheduler-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: custom-scheduler
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: custom-scheduler
+  template:
+    metadata:
+      labels:
+        app: custom-scheduler
+    spec:
+      containers:
+      - name: custom-scheduler
+        image: custom-scheduler:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 10259
+      serviceAccountName: custom-scheduler


### PR DESCRIPTION
Add `custom-scheduler-deployment.yaml` to register `customScheduler` for minikube with docker engine.

* Create a new deployment file `custom-scheduler-deployment.yaml` with the necessary configuration to deploy the custom scheduler plugin.
* Set the image to use the custom scheduler plugin and set the replicas to 1.
* Set the namespace to `kube-system`.

Update `README.md` to include instructions for deploying the custom scheduler plugin using `custom-scheduler-deployment.yaml`.

* Update the deployment instructions to use `custom-scheduler-deployment.yaml`.
* Update the command to deploy the custom scheduler plugin.
* Update the command to verify the custom scheduler plugin.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogakzbj9/customScheduler/pull/8?shareId=b1b19215-9552-4b0d-9b3d-3e6789e07fcf).