### PR TITLE
Add label to custom-scheduler deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,19 @@ To deploy the custom scheduler plugin to your Kubernetes cluster, follow these s
    ```sh
    kubectl get configmap custom-scheduler-config
    ```
-3. Deploy the custom scheduler plugin as a Kubernetes Deployment:
+3. Verify the creation of the custom-scheduler deployment:
+   ```sh
+   kubectl get deployments -n kube-system -l app=custom-scheduler
+   ```
+4. Deploy the custom scheduler plugin as a Kubernetes Deployment:
    ```sh
    kubectl apply -f custom-scheduler-deployment.yaml
    ```
-4. Verify that the custom scheduler plugin is running:
+5. Verify that the custom scheduler plugin is running:
    ```sh
    kubectl get pods -n kube-system -l app=custom-scheduler
    ```
-5. Verify the correctness of the command execution results:
+6. Verify the correctness of the command execution results:
    ```sh
    kubectl logs <pod-name> -n kube-system
    ```

--- a/custom-scheduler-deployment.yaml
+++ b/custom-scheduler-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: custom-scheduler
   namespace: kube-system
+  labels:
+    app: custom-scheduler
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Add verification step for custom-scheduler deployment and update deployment configuration.

* **README.md**
  - Add a new verification step to include the command 'kubectl get deployments -n kube-system -l app=custom-scheduler' after verifying the creation of the ConfigMap.
  - Update the step numbers accordingly.

* **custom-scheduler-deployment.yaml**
  - Add the `labels` field with `app: custom-scheduler` under the `metadata` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogakzbj9/customScheduler/pull/10?shareId=2717c4c6-6f91-46db-b555-4788a08f1100).