### PR TITLE
Update Dockerfile to use busybox and add pre-built custom scheduler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-# Use golang:1.22 as the base image
-FROM golang:1.22
+# Use busybox as the base image
+FROM busybox
 
 # Set the working directory inside the container
 WORKDIR /app
 
-# Copy the project files into the Docker image
-COPY . .
-
-# Build the custom scheduler binary inside the Docker image
-RUN go build -o custom-scheduler .
+# Add the pre-built custom scheduler binary to the Docker image
+ADD custom-scheduler /app/custom-scheduler
 
 # Set the entrypoint to the custom scheduler binary
 ENTRYPOINT ["./custom-scheduler"]

--- a/README.md
+++ b/README.md
@@ -5,25 +5,6 @@
 This project implements a custom scheduler plugin for Kubernetes. The custom scheduler plugin allows you to define custom scheduling logic for your Kubernetes cluster.
 This project is under construction.
 
-
-## Building the Custom Scheduler Plugin
-
-To build the custom scheduler plugin, follow these steps:
-
-1. Ensure you have a Kubernetes cluster and the necessary tools for development, such as Go and kubectl.
-2. Clone the repository:
-   ```sh
-   git clone https://github.com/kogakzbj9/customScheduler.git
-   ```
-3. Navigate to the project directory:
-   ```sh
-   cd customScheduler
-   ```
-4. Build the custom scheduler plugin:
-   ```sh
-   go build -o custom-scheduler .
-   ```
-
 ## Building the Docker Image
 
 To build the Docker image for the custom scheduler, follow these steps:


### PR DESCRIPTION
Update Dockerfile to use busybox as the base image and modify README.md accordingly.

* **Dockerfile**
  - Change the base image to `busybox`.
  - Add the pre-built custom scheduler binary to the Docker image.
  - Remove the Go build step.

* **README.md**
  - Remove the build instructions for the custom scheduler plugin.
  - Update the Docker build instructions to reflect the new Dockerfile.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogakzbj9/customScheduler/pull/13?shareId=17a923c5-2834-496f-aa50-47e5ca46897d).