### PR TITLE
Add build steps for custom scheduler binary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 This project implements a custom scheduler plugin for Kubernetes. The custom scheduler plugin allows you to define custom scheduling logic for your Kubernetes cluster.
 This project is under construction.
 
+## Building the Custom Scheduler Binary
+
+To build the custom scheduler binary, follow these steps:
+
+1. Ensure you have Go installed on your machine.
+2. Navigate to the project directory:
+   ```sh
+   cd customScheduler
+   ```
+3. Build the custom scheduler binary:
+   ```sh
+   go build -o custom-scheduler .
+   ```
+
 ## Building the Docker Image
 
 To build the Docker image for the custom scheduler, follow these steps:


### PR DESCRIPTION
Add build steps for the custom scheduler binary to the `README.md`.

* **Building the Custom Scheduler Binary**
  - Add a new section "Building the Custom Scheduler Binary" to the `README.md`.
  - Include steps to build the custom scheduler binary using `go build`.
  - Provide commands to navigate to the project directory and build the binary.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogakzbj9/customScheduler/pull/15?shareId=9a3e834a-9824-48c0-8722-afc92d95e56c).