### PR TITLE
Add Minikube instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,16 @@ To build the custom scheduler binary, follow these steps:
 To build the Docker image for the custom scheduler, follow these steps:
 
 1. Ensure you have Docker installed on your machine.
-2. Navigate to the project directory:
+2. If you are using Minikube, run the following command to set up the Docker environment:
+   ```sh
+   eval $(minikube docker-env)
+   ```
+   This command configures Docker to use the Minikube Docker daemon, allowing you to build Docker images directly inside the Minikube environment.
+3. Navigate to the project directory:
    ```sh
    cd customScheduler
    ```
-3. Build the Docker image:
+4. Build the Docker image:
    ```sh
    docker build -t custom-scheduler:latest .
    ```


### PR DESCRIPTION
Add instructions for Minikube Docker environment setup in `README.md`.

* Add a step to run `eval $(minikube docker-env)` before building the Docker image.
* Add an explanation for running `eval $(minikube docker-env)` to the "Building the Docker Image" section.
* Update the step numbers accordingly in the "Building the Docker Image" section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogakzbj9/customScheduler/pull/16?shareId=ed181c40-3be5-4668-aa22-c27143f7a2d5).