### PR TITLE
Add log level configuration to custom scheduler

### DIFF
--- a/custom-scheduler-deployment.yaml
+++ b/custom-scheduler-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 10259
+        args: ["-v=${LOG_LEVEL}"]
+        env:
+        - name: LOG_LEVEL
+          value: "2"
         volumeMounts:
         - name: custom-scheduler-config
           mountPath: /etc/custom-scheduler


### PR DESCRIPTION
Add LOG_LEVEL environment variable and set default value to 2 in custom-scheduler-deployment.yaml

* Add `args: ["-v=${LOG_LEVEL}"]` under the `containers` section
* Add `env` section to set `LOG_LEVEL` to 2

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kogakzbj9/customScheduler/pull/21?shareId=ebfda210-074f-47ff-9408-6921365cebe9).